### PR TITLE
Parse errors wrapper setting class

### DIFF
--- a/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
+++ b/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
@@ -23,4 +23,9 @@ class ParseErrorsWrapperSetting
         return true;
     }
 
+    public function getIndentation() : string
+    {
+        return "    ";
+    }
+
 }

--- a/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
+++ b/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
@@ -28,4 +28,18 @@ class ParseErrorsWrapperSetting
         return "    ";
     }
 
+    public function __construct(
+        private string $rootHeaderLabel
+    )
+    {
+    }
+
+    /**
+     * @return string
+     */
+    public function getRootHeaderLabel() : string
+    {
+        return $this->rootHeaderLabel;
+    }
+
 }

--- a/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
+++ b/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
@@ -5,7 +5,22 @@ declare(strict_types=1);
 
 namespace Endermanbugzjfc\ConfigStruct;
 
+use Endermanbugzjfc\ConfigStruct\ParseError\BaseParseError;
+
 class ParseErrorsWrapperSetting
 {
+
+    /**
+     * @param array $keys A list of error labels that can be used for identifying which error in the tree has just been walked.
+     * @param BaseParseError $parseError
+     * @return bool False = the error will not be displayed in the final error message.
+     */
+    public function errorFilter(
+        array          $keys,
+        BaseParseError $parseError
+    ) : bool
+    {
+        return true;
+    }
 
 }

--- a/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
+++ b/ConfigStruct/src/Endermanbugzjfc/ConfigStruct/ParseErrorsWrapperSetting.php
@@ -1,0 +1,11 @@
+<?php
+
+
+declare(strict_types=1);
+
+namespace Endermanbugzjfc\ConfigStruct;
+
+class ParseErrorsWrapperSetting
+{
+
+}


### PR DESCRIPTION
Currently (2.0.0-BETA2), you must run `$parseErrorsWrapper->regenerateErrorMessage()` in order to customise the error message. Using one function for all settings is a probably bad idea because it is hard to maintain backward compatibility when adding or removing certain settings.

# Concept
Users can extend the setting class to set their own settings. I am not sure if this is an abuse of class inheritance.